### PR TITLE
fix(backend): fix http CVE-2024-45336

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
 
 USER root
 # Downloading Argo CLI so that the samples are validated

--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for building the source code of cache_server
-FROM golang:1.21.7-alpine3.19 as builder
+FROM golang:1.22.12-alpine3.19 as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev

--- a/backend/Dockerfile.conformance
+++ b/backend/Dockerfile.conformance
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for building the source code of conformance tests
-FROM golang:1.21.7-alpine3.19 as builder
+FROM golang:1.22.12-alpine3.19 as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi8/nodejs-14 as base image
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
 
 
 ## Build args to be used at this step

--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 AS builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22 AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.konflux.driver
+++ b/backend/Dockerfile.konflux.driver
@@ -15,7 +15,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 as builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22 as builder
 
 
 ## Build args to be used at this step

--- a/backend/Dockerfile.konflux.launcher
+++ b/backend/Dockerfile.konflux.launcher
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi8/nodejs-14 as base image
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 as builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.konflux.persistenceagent
+++ b/backend/Dockerfile.konflux.persistenceagent
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi8/go-toolset as base image
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 as builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.konflux.scheduledworkflow
+++ b/backend/Dockerfile.konflux.scheduledworkflow
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi8/go-toolset as base image
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 as builder
+FROM registry.redhat.io/ubi8/go-toolset:1.22 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -18,7 +18,7 @@ ARG CI_CONTAINER_VERSION="unknown"
 
 
 # Use ubi8/nodejs-14 as base image
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
 
 
 ## Build args to be used at this step

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -18,7 +18,7 @@ ARG CI_CONTAINER_VERSION="unknown"
 
 
 # Use ubi8/go-toolset as base image
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi8/nodejs-14 as base image
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.7-alpine3.19 as builder
+FROM golang:1.22.12-alpine3.19 as builder
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache git gcc musl-dev

--- a/go.mod
+++ b/go.mod
@@ -220,6 +220,6 @@ replace (
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.2.9
 )
 
-go 1.21
+go 1.22
 
 exclude github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f

--- a/go.sum
+++ b/go.sum
@@ -1597,8 +1597,6 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
-github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
-github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
**Description of your changes:**
The fix for http https://github.com/advisories/GHSA-7wrw-r4p8-38rx is upgrading to go 1.22.12 (since http is a built-in go module). A manual change from 1.21 to 1.22 was needed on the images, as Konflux jobs won't make this change on their own. With the manual (minor version) change in place, Konflux is expected to continue to update images on the 1.22.x line.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
