### PR TITLE
fix: add missing context

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,5 +1,5 @@
 arches:
-- x86_64
+  - x86_64
 contentOrigin:
   repofiles:
     - ubi.repo
@@ -9,3 +9,5 @@ packages:
   - openssl
   - ca-certificates
   - wget
+context:
+  containerfile: backend/Dockerfile.konflux.api


### PR DESCRIPTION
Add missing context field required by mintmaker automation