### PR TITLE
RHOAI cherry-pick: Make the target branch dynamic in the CI

### DIFF
--- a/.github/workflows/kfp-kubernetes-execution-tests.yml
+++ b/.github/workflows/kfp-kubernetes-execution-tests.yml
@@ -81,6 +81,7 @@ jobs:
         env:
           PULL_NUMBER: ${{ github.event.pull_request.number }}
           REPO_NAME: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
           export KFP_ENDPOINT="http://localhost:8888"
           export TIMEOUT_SECONDS=2700

--- a/.github/workflows/kfp-samples.yml
+++ b/.github/workflows/kfp-samples.yml
@@ -81,6 +81,7 @@ jobs:
       env:
         PULL_NUMBER: ${{ github.event.pull_request.number }}
         REPO_NAME: ${{ github.repository }}
+        TARGET_BRANCH: ${{ github.ref_name }}
       run: |
         ./backend/src/v2/test/sample-test.sh
       continue-on-error: true

--- a/.github/workflows/kfp-sdk-runtime-tests.yml
+++ b/.github/workflows/kfp-sdk-runtime-tests.yml
@@ -33,4 +33,5 @@ jobs:
         run: |
           export PULL_NUMBER="${{ github.event.inputs.pull_number || github.event.pull_request.number }}"
           export REPO_NAME="${{ github.repository }}"
+          export TARGET_BRANCH="${{ github.ref_name }}"
           ./test/presubmit-test-kfp-runtime-code.sh

--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           PULL_NUMBER: ${{ github.event.pull_request.number }}
           REPO_NAME: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
           export KFP_ENDPOINT="http://localhost:8888"
           export TIMEOUT_SECONDS=2700

--- a/backend/src/v2/test/sample-test.sh
+++ b/backend/src/v2/test/sample-test.sh
@@ -17,12 +17,13 @@
 set -ex
 
 REPO_NAME="${REPO_NAME:-example-test-organization/pipelines}"
+TARGET_BRANCH="${TARGET_BRANCH:-master}"
 
 if [[ -n "${PULL_NUMBER}" ]]; then
   export KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@refs/pull/${PULL_NUMBER}/merge#egg=kfp&subdirectory=sdk/python"
 
 else
-  export KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}#egg=kfp&subdirectory=sdk/python"
+  export KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@${TARGET_BRANCH}#egg=kfp&subdirectory=sdk/python"
 fi
 
 python3 -m pip install --upgrade pip

--- a/backend/src/v2/test/scripts/ci-env.sh
+++ b/backend/src/v2/test/scripts/ci-env.sh
@@ -19,9 +19,10 @@ GCR_ROOT="gcr.io/${PROJECT}/${COMMIT_SHA}/v2-sample-test"
 # This is kfp-ci endpoint.
 HOST=${HOST:-"https://$(curl https://raw.githubusercontent.com/kubeflow/testing/master/test-infra/kfp/endpoint)"}
 REPO_NAME="${REPO_NAME:-kubeflow/pipelines}"
+TARGET_BRANCH="${TARGET_BRANCH:-master}"
 
 if [[ -z "${PULL_NUMBER}" ]]; then
-  KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}#egg=kfp&subdirectory=sdk/python"
+  KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@${TARGET_BRANCH}#egg=kfp&subdirectory=sdk/python"
 else
   KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@refs/pull/${PULL_NUMBER}/merge#egg=kfp&subdirectory=sdk/python"
 fi

--- a/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
+++ b/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
@@ -111,10 +111,11 @@ def run(test_case: TestCase) -> Tuple[str, client.client.RunPipelineResult]:
 
 def get_kfp_package_path() -> str:
     repo_name = os.environ.get('REPO_NAME', 'kubeflow/pipelines')
+    target_branch = os.environ.get('TARGET_BRANCH', 'master')
     if os.environ.get('PULL_NUMBER'):
         path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
-        path = f'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
+        path = f'git+https://github.com/{repo_name}.git@{target_branch}#subdirectory=sdk/python'
     print(f'Using the following KFP package path for tests: {path}')
     return path
 

--- a/test/sdk-execution-tests/sdk_execution_tests.py
+++ b/test/sdk-execution-tests/sdk_execution_tests.py
@@ -105,10 +105,11 @@ def run(test_case: TestCase) -> Tuple[str, client.client.RunPipelineResult]:
 
 def get_kfp_package_path() -> str:
     repo_name = os.environ.get('REPO_NAME', 'kubeflow/pipelines')
+    target_branch = os.environ.get('TARGET_BRANCH', 'master')
     if os.environ.get('PULL_NUMBER'):
         path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
-        path = f'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
+        path = f'git+https://github.com/{repo_name}.git@{target_branch}#subdirectory=sdk/python'
     print(f'Using the following KFP package path for tests: {path}')
     return path
 


### PR DESCRIPTION
**Description of your changes:**

This allows branches other than master to use the proper SDK on pushes. This should fix the CI. For example:
https://github.com/red-hat-data-services/data-science-pipelines/actions/runs/14919527382/job/41912132723

(cherry picked from commit 0ecd165cceb2d05ccc2bb638460d66906380b0e4 https://github.com/kubeflow/pipelines/pull/11904)


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
