### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-ml-pipelines-launcher-v2-22

### DIFF
--- a/backend/Dockerfile.konflux.launcher
+++ b/backend/Dockerfile.konflux.launcher
@@ -44,7 +44,8 @@ RUN chmod +x /bin/launcher-v2 && chmod +x /bin/launcher-v2-fips
 ENTRYPOINT ["/bin/launcher-v2"]
 
 LABEL com.redhat.component="odh-ml-pipelines-launcher-container" \
-      name="managed-open-data-hub/odh-ml-pipelines-launcher-rhel8" \
+      name="rhoai/odh-ml-pipelines-launcher-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="odh-ml-pipelines-launcher" \
       summary="odh-ml-pipelines-launcher" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
