### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-ml-pipelines-driver-v2-22

### DIFF
--- a/backend/Dockerfile.konflux.driver
+++ b/backend/Dockerfile.konflux.driver
@@ -42,7 +42,8 @@ RUN chmod +x /bin/driver
 ENTRYPOINT ["/bin/driver"]
 
 LABEL com.redhat.component="odh-ml-pipelines-driver-container" \
-      name="managed-open-data-hub/odh-ml-pipelines-driver-rhel8" \
+      name="rhoai/odh-ml-pipelines-driver-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="odh-ml-pipelines-driver" \
       summary="odh-ml-pipelines-driver" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
