### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-ml-pipelines-api-server-v2-v2-22

### DIFF
--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -54,7 +54,8 @@ EXPOSE 8888
 CMD /bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true
 
 LABEL com.redhat.component="odh-ml-pipelines-api-server-v2-container" \
-      name="managed-open-data-hub/odh-ml-pipelines-api-server-v2-rhel8" \
+      name="rhoai/odh-ml-pipelines-api-server-v2-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="odh-ml-pipelines-api-server-v2" \
       summary="odh-ml-pipelines-api-server-v2" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
