### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-ml-pipelines-persistenceagent-v2-v2-21

### DIFF
--- a/backend/Dockerfile.konflux.persistenceagent
+++ b/backend/Dockerfile.konflux.persistenceagent
@@ -50,7 +50,8 @@ ENV NUM_WORKERS 2
 CMD persistence_agent --logtostderr=true --namespace=${NAMESPACE} --ttlSecondsAfterWorkflowFinish=${TTL_SECONDS_AFTER_WORKFLOW_FINISH} --numWorker ${NUM_WORKERS}
 
 LABEL com.redhat.component="odh-ml-pipelines-persistenceagent-v2-container" \
-      name="managed-open-data-hub/odh-ml-pipelines-persistenceagent-v2-rhel8" \
+      name="rhoai/odh-ml-pipelines-persistenceagent-v2-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.21::el9" \
       description="odh-ml-pipelines-persistenceagent-v2" \
       summary="odh-ml-pipelines-persistenceagent-v2" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
