### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-ml-pipelines-scheduledworkflow-v2-v2-20

### DIFF
--- a/backend/Dockerfile.konflux.scheduledworkflow
+++ b/backend/Dockerfile.konflux.scheduledworkflow
@@ -46,7 +46,8 @@ ENV NAMESPACE ""
 CMD /bin/controller --logtostderr=true --namespace=${NAMESPACE}
 
 LABEL com.redhat.component="odh-ml-pipelines-scheduledworkflow-v2-container" \
-      name="managed-open-data-hub/odh-ml-pipelines-scheduledworkflow-v2-rhel8" \
+      name="rhoai/odh-ml-pipelines-scheduledworkflow-v2-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       description="odh-ml-pipelines-scheduledworkflow-v2" \
       summary="odh-ml-pipelines-scheduledworkflow-v2" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
