### PR TITLE
fix: pin trivy workflow actions to commit SHAs (GHSA-69fq-xp46-6x23)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -23,6 +23,6 @@ jobs:
           skip-dirs: 'components'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions in `trivy.yml` to immutable commit SHAs instead of mutable tags to mitigate supply chain attacks like [GHSA-69fq-xp46-6x23](https://github.com/advisories/GHSA-69fq-xp46-6x23)
- Upgrades `aquasecurity/trivy-action` from `0.28.0` to `v0.35.0` (patched version)
- Pins `actions/checkout` and `github/codeql-action/upload-sarif` to commit SHAs

## Test plan
- [ ] Verify trivy workflow runs successfully on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)