### PR TITLE
fix(backend): stop requiring workspace PVC storageClassName (#13306)

### DIFF
--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -653,8 +653,12 @@ func GetWorkspacePVC(
 		return k8score.PersistentVolumeClaim{}, fmt.Errorf("workspace PVC spec must specify accessModes")
 	}
 
-	if pvcSpec.StorageClassName == nil || *pvcSpec.StorageClassName == "" {
-		return k8score.PersistentVolumeClaim{}, fmt.Errorf("workspace PVC spec must specify storageClassName")
+	// Allow nil storageClassName so Kubernetes can apply the cluster default.
+	// Explicit empty string requests "no storage class" behavior and is rejected.
+	if pvcSpec.StorageClassName != nil && *pvcSpec.StorageClassName == "" {
+		return k8score.PersistentVolumeClaim{}, fmt.Errorf(
+			"workspace PVC spec storageClassName must be omitted or set to a non-empty value",
+		)
 	}
 
 	quantity, err := k8sres.ParseQuantity(sizeStr)

--- a/backend/src/v2/compiler/argocompiler/argo_workspace_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_workspace_test.go
@@ -209,6 +209,56 @@ func TestGetWorkspacePVC(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "workspace with nil storageClassName should succeed",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "8Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"accessModes": structpb.NewListValue(&structpb.ListValue{
+								Values: []*structpb.Value{
+									structpb.NewStringValue("ReadWriteOnce"),
+								},
+							}),
+						},
+					},
+				},
+			},
+			opts: nil,
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with explicit empty storageClassName should fail",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "8Gi",
+			},
+			opts: &argocompiler.Options{
+				DefaultWorkspace: &k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					StorageClassName: stringPtr(""),
+				},
+			},
+			expectedPVC: k8score.PersistentVolumeClaim{},
+			expectError: true,
+		},
+		{
 			name: "workspace with invalid PVC spec patch",
 			workspace: &pipelinespec.WorkspaceConfig{
 				Size: "10Gi",


### PR DESCRIPTION
Allow workspace PVC specs to omit storageClassName so clusters can apply their default storage class without compiler validation failures.

**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
