### PR TITLE
ci: enforce Go version consistency in workflows and Dockerfiles

### DIFF
--- a/.github/scripts/go-version-consistency-ignore
+++ b/.github/scripts/go-version-consistency-ignore
@@ -1,0 +1,6 @@
+# Dockerfiles excluded from Go version consistency check.
+# One path per line, relative to repo root. Comments (#) and blank lines are allowed.
+
+# Builds an external tool (build-machinery-go/commitchecker),
+# not tied to this repo's Go module.
+tools/commit_checker/Dockerfile

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -20,7 +20,8 @@ IGNORED_PATHS=()
 if [[ -f "$IGNORE_FILE" ]]; then
     while IFS= read -r line; do
         line="${line%%#*}"
-        line=$(echo "$line" | xargs)
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
         [[ -n "$line" ]] && IGNORED_PATHS+=("$line")
     done < "$IGNORE_FILE"
 fi
@@ -41,10 +42,12 @@ version_matches() {
 
 ERRORS=0
 CHECKED=0
+TOTAL_FOUND=0
 FOUND=0
 
 while IFS= read -r dockerfile; do
     relative="${dockerfile#"$REPO_ROOT"/}"
+    TOTAL_FOUND=$((TOTAL_FOUND + 1))
     skip=false
     for ignored in "${IGNORED_PATHS[@]}"; do
         if [[ "$relative" == "$ignored" ]]; then
@@ -73,13 +76,18 @@ while IFS= read -r dockerfile; do
             echo "  OK: $relative (Go $docker_version)"
         fi
     done < <(grep -iE '^FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' "$dockerfile" || true)
-done < <(cd "$REPO_ROOT" && (git ls-files '*Dockerfile*' | xargs grep -liE 'FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' | sed "s|^|$REPO_ROOT/|") || true)
+done < <(cd "$REPO_ROOT" && (git ls-files -z '*Dockerfile*' | xargs -0 grep -liE -- 'FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' | sed "s|^|$REPO_ROOT/|") || true)
 
 echo ""
 
-if [[ $FOUND -eq 0 ]]; then
+if [[ $TOTAL_FOUND -eq 0 ]]; then
     echo "ERROR: No Dockerfiles with Go base images found." >&2
     exit 1
+fi
+
+if [[ $FOUND -eq 0 ]]; then
+    echo "INFO: All $TOTAL_FOUND Dockerfile(s) with Go base images are ignored. Nothing to check."
+    exit 0
 fi
 
 if [[ $CHECKED -eq 0 ]]; then

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+if ! command -v skopeo &>/dev/null; then
+    echo "ERROR: skopeo is required but not found in PATH" >&2
+    exit 1
+fi
+
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
 GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' || true)
@@ -26,18 +31,27 @@ if [[ -f "$IGNORE_FILE" ]]; then
     done < "$IGNORE_FILE"
 fi
 
-version_matches() {
-    local docker_version="$1" gomod_version="$2"
-    local docker_major_minor gomod_major_minor
-    docker_major_minor=$(echo "$docker_version" | cut -d. -f1-2)
-    gomod_major_minor=$(echo "$gomod_version" | cut -d. -f1-2)
-    if [[ "$docker_major_minor" != "$gomod_major_minor" ]]; then
-        return 1
+resolve_go_version() {
+    local image_ref="$1" tag_version="$2"
+    if [[ "$tag_version" == *.*.* ]]; then
+        echo "$tag_version"
+        return
     fi
-    if [[ "$docker_version" == *.*.* && "$gomod_version" == *.*.* ]]; then
-        [[ "$docker_version" != "$gomod_version" ]] && return 1
+    local resolved skopeo_stderr
+    skopeo_stderr=$(mktemp)
+    resolved=$(skopeo inspect --override-arch amd64 --override-os linux "docker://$image_ref" 2>"$skopeo_stderr" \
+        | grep -oE '"(VERSION|GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+"' \
+        | head -1 \
+        | sed -E 's/"(VERSION|GOLANG_VERSION)=([0-9]+\.[0-9]+\.[0-9]+)"/\2/')
+    if [[ -z "$resolved" ]]; then
+        echo "  skopeo inspect failed for $image_ref:" >&2
+        cat "$skopeo_stderr" >&2
+        rm -f "$skopeo_stderr"
+        echo ""
+        return
     fi
-    return 0
+    rm -f "$skopeo_stderr"
+    echo "$resolved"
 }
 
 ERRORS=0
@@ -67,13 +81,27 @@ while IFS= read -r dockerfile; do
             continue
         fi
 
+        image_ref=$(echo "$line" | sed -E 's/^FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*([^[:space:]]+)[[:space:]]*.*/\2/')
+
+        resolved_version=$(resolve_go_version "$image_ref" "$docker_version")
+
+        if [[ -z "$resolved_version" ]]; then
+            echo "ERROR: Could not resolve Go version from image $image_ref in $relative" >&2
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+
         CHECKED=$((CHECKED + 1))
 
-        if ! version_matches "$docker_version" "$GOMOD_VERSION"; then
-            echo "MISMATCH: $relative has Go $docker_version, but go.mod requires $GOMOD_VERSION" >&2
+        if [[ "$resolved_version" != "$docker_version" ]]; then
+            echo "  INFO: $relative tag $docker_version resolved to Go $resolved_version"
+        fi
+
+        if [[ "$resolved_version" != "$GOMOD_VERSION" ]]; then
+            echo "MISMATCH: $relative has Go $resolved_version, but go.mod requires $GOMOD_VERSION" >&2
             ERRORS=$((ERRORS + 1))
         else
-            echo "  OK: $relative (Go $docker_version)"
+            echo "  OK: $relative (Go $resolved_version)"
         fi
     done < <(grep -iE '^FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' "$dockerfile" || true)
 done < <(cd "$REPO_ROOT" && (git ls-files -z '*Dockerfile*' | xargs -0 grep -liE -- 'FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' | sed "s|^|$REPO_ROOT/|") || true)

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Verifies that all Dockerfiles using a golang or go-toolset base image
+# specify a Go version consistent with the root go.mod.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+GOMOD_VERSION=$(grep -E '^go [0-9]' "$REPO_ROOT/go.mod" | awk '{print $2}' || true)
+
+if [[ -z "$GOMOD_VERSION" ]]; then
+    echo "ERROR: Could not extract Go version from go.mod" >&2
+    exit 1
+fi
+
+echo "go.mod Go version: $GOMOD_VERSION"
+
+version_matches() {
+    local docker_version="$1" gomod_version="$2"
+    local docker_major_minor gomod_major_minor
+    docker_major_minor=$(echo "$docker_version" | cut -d. -f1-2)
+    gomod_major_minor=$(echo "$gomod_version" | cut -d. -f1-2)
+    if [[ "$docker_major_minor" != "$gomod_major_minor" ]]; then
+        return 1
+    fi
+    if [[ "$docker_version" == *.*.* && "$gomod_version" == *.*.* ]]; then
+        [[ "$docker_version" != "$gomod_version" ]] && return 1
+    fi
+    return 0
+}
+
+ERRORS=0
+CHECKED=0
+FOUND=0
+
+while IFS= read -r dockerfile; do
+    relative="${dockerfile#"$REPO_ROOT"/}"
+    FOUND=$((FOUND + 1))
+    while IFS= read -r line; do
+        docker_version=$(echo "$line" | sed -E 's/.*FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):([0-9]+\.[0-9]+(\.[0-9]+)?).*/\3/')
+
+        if [[ ! "$docker_version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "ERROR: Could not parse Go version from line in $relative: $line" >&2
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+
+        CHECKED=$((CHECKED + 1))
+
+        if ! version_matches "$docker_version" "$GOMOD_VERSION"; then
+            echo "MISMATCH: $relative has Go $docker_version, but go.mod requires $GOMOD_VERSION" >&2
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "  OK: $relative (Go $docker_version)"
+        fi
+    done < <(grep -iE '^FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' "$dockerfile" || true)
+done < <(cd "$REPO_ROOT" && (git ls-files '*Dockerfile*' | xargs grep -liE 'FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):' | sed "s|^|$REPO_ROOT/|") || true)
+
+echo ""
+
+if [[ $FOUND -eq 0 ]]; then
+    echo "ERROR: No Dockerfiles with Go base images found." >&2
+    exit 1
+fi
+
+if [[ $CHECKED -eq 0 ]]; then
+    echo "ERROR: Found $FOUND Dockerfile(s) with Go base images, but could not parse any Go version." >&2
+    exit 1
+fi
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "FAILED: $ERRORS error(s) found when checking Go base image stages against go.mod ($GOMOD_VERSION)." >&2
+    exit 1
+fi
+
+echo "PASSED: All $CHECKED Go base image stage(s) use Go $GOMOD_VERSION, matching go.mod."

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -15,6 +15,16 @@ fi
 
 echo "go.mod Go version: $GOMOD_VERSION"
 
+IGNORE_FILE="$REPO_ROOT/.github/scripts/go-version-consistency-ignore"
+IGNORED_PATHS=()
+if [[ -f "$IGNORE_FILE" ]]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line=$(echo "$line" | xargs)
+        [[ -n "$line" ]] && IGNORED_PATHS+=("$line")
+    done < "$IGNORE_FILE"
+fi
+
 version_matches() {
     local docker_version="$1" gomod_version="$2"
     local docker_major_minor gomod_major_minor
@@ -35,6 +45,15 @@ FOUND=0
 
 while IFS= read -r dockerfile; do
     relative="${dockerfile#"$REPO_ROOT"/}"
+    skip=false
+    for ignored in "${IGNORED_PATHS[@]}"; do
+        if [[ "$relative" == "$ignored" ]]; then
+            echo "  SKIP: $relative (ignored)"
+            skip=true
+            break
+        fi
+    done
+    [[ "$skip" == true ]] && continue
     FOUND=$((FOUND + 1))
     while IFS= read -r line; do
         docker_version=$(echo "$line" | sed -E 's/.*FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(golang|[^[:space:]]*go-toolset):([0-9]+\.[0-9]+(\.[0-9]+)?).*/\3/')

--- a/.github/scripts/verify-go-version-consistency.sh
+++ b/.github/scripts/verify-go-version-consistency.sh
@@ -37,9 +37,12 @@ resolve_go_version() {
         echo "$tag_version"
         return
     fi
-    local resolved skopeo_stderr
+    local resolved skopeo_stderr skopeo_ref="$image_ref"
+    if [[ "$skopeo_ref" == *:*@* ]]; then
+        skopeo_ref="${skopeo_ref%%:*}@${skopeo_ref#*@}"
+    fi
     skopeo_stderr=$(mktemp)
-    resolved=$(skopeo inspect --override-arch amd64 --override-os linux "docker://$image_ref" 2>"$skopeo_stderr" \
+    resolved=$(skopeo inspect --override-arch amd64 --override-os linux "docker://$skopeo_ref" 2>"$skopeo_stderr" \
         | grep -oE '"(VERSION|GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+"' \
         | head -1 \
         | sed -E 's/"(VERSION|GOLANG_VERSION)=([0-9]+\.[0-9]+\.[0-9]+)"/\2/')

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -1,0 +1,21 @@
+name: Go Version Consistency
+
+on:
+  pull_request:
+    paths:
+      - '**/go.mod'
+      - '**/Dockerfile*'
+      - '.github/scripts/verify-go-version-consistency.sh'
+      - '.github/workflows/go-version-consistency.yml'
+
+jobs:
+  verify-go-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Verify Go version consistency
+        run: bash .github/scripts/verify-go-version-consistency.sh

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -6,6 +6,7 @@ on:
       - '**/go.mod'
       - '**/Dockerfile*'
       - '.github/scripts/verify-go-version-consistency.sh'
+      - '.github/scripts/go-version-consistency-ignore'
       - '.github/workflows/go-version-consistency.yml'
 
 jobs:

--- a/.github/workflows/go-version-consistency.yml
+++ b/.github/workflows/go-version-consistency.yml
@@ -3,7 +3,7 @@ name: Go Version Consistency
 on:
   pull_request:
     paths:
-      - '**/go.mod'
+      - 'go.mod'
       - '**/Dockerfile*'
       - '.github/scripts/verify-go-version-consistency.sh'
       - '.github/scripts/go-version-consistency-ignore'

--- a/backend/test/images/Dockerfile.test
+++ b/backend/test/images/Dockerfile.test
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.7-bookworm AS builder
 
 # Update package repo and install required libraries
 RUN apt-get update && apt-get install -y cmake clang musl-dev openssl


### PR DESCRIPTION
**Description of your changes:**
Added a GitHub Actions workflow to verify that all Dockerfiles using Go base images specify a Go version consistent with the root `go.mod`. Introduced a shell script to validate Go version alignment.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [x] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
