### PR TITLE
chore(ci): noop comments on PR #1435 Dockerfile set

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,5 +1,7 @@
 module github.com/kubeflow/pipelines/api
 
+// CI noop: same go.mod paths as PR #1435 (CVE bump); no functional change — infra vs PR comparison.
+
 go 1.24.6
 
 require (

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -86,3 +86,5 @@ EXPOSE 8888
 
 # Start the apiserver
 CMD ["/bin/sh", "-c", "/bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true --logLevel=${LOG_LEVEL}"]
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -41,3 +41,5 @@ WORKDIR /bin
 COPY --from=builder /bin/cache_server /bin/cache_server
 
 ENTRYPOINT [ "/bin/cache_server" ]
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.conformance
+++ b/backend/Dockerfile.conformance
@@ -47,3 +47,5 @@ RUN tar -xzvf /test.tar.gz
 WORKDIR /test/integration
 
 ENTRYPOINT [ "./run.sh" ]
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -48,3 +48,5 @@ ENTRYPOINT ["/bin/driver"]
 
 LABEL name="ds-pipelines-driver" \
       summary="DSP Driver"
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -63,3 +63,5 @@ LABEL com.redhat.component="odh-ml-pipelines-api-server-v2-container" \
       io.k8s.display-name="odh-ml-pipelines-api-server-v2" \
       io.k8s.description="odh-ml-pipelines-api-server-v2" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.konflux.driver
+++ b/backend/Dockerfile.konflux.driver
@@ -52,3 +52,5 @@ LABEL com.redhat.component="odh-ml-pipelines-driver-container" \
       io.k8s.display-name="odh-ml-pipelines-driver" \
       io.k8s.description="odh-ml-pipelines-driver" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.konflux.launcher
+++ b/backend/Dockerfile.konflux.launcher
@@ -53,3 +53,5 @@ LABEL com.redhat.component="odh-ml-pipelines-launcher-container" \
       io.k8s.display-name="odh-ml-pipelines-launcher" \
       io.k8s.description="odh-ml-pipelines-launcher" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.konflux.persistenceagent
+++ b/backend/Dockerfile.konflux.persistenceagent
@@ -59,3 +59,5 @@ LABEL com.redhat.component="odh-ml-pipelines-persistenceagent-v2-container" \
       io.k8s.description="odh-ml-pipelines-persistenceagent-v2" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.konflux.scheduledworkflow
+++ b/backend/Dockerfile.konflux.scheduledworkflow
@@ -53,3 +53,5 @@ LABEL com.redhat.component="odh-ml-pipelines-scheduledworkflow-v2-container" \
       io.k8s.display-name="odh-ml-pipelines-scheduledworkflow-v2" \
       io.k8s.description="odh-ml-pipelines-scheduledworkflow-v2" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -52,3 +52,5 @@ ENTRYPOINT ["/bin/launcher-v2"]
 
 LABEL name="ds-pipelines-launcher" \
       summary="DSP launcher"
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -54,3 +54,5 @@ ENV LOG_LEVEL=info
 ENV EXECUTIONTYPE=Workflow
 
 CMD ["/bin/sh", "-c", "persistence_agent --logtostderr=true --namespace=${NAMESPACE} --ttlSecondsAfterWorkflowFinish=${TTL_SECONDS_AFTER_WORKFLOW_FINISH} --numWorker ${NUM_WORKERS} --executionType ${EXECUTIONTYPE} --logLevel=${LOG_LEVEL}"]
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -55,3 +55,5 @@ ENV NAMESPACE=""
 ENV LOG_LEVEL=info
 
 CMD /bin/controller --logtostderr=true --namespace=${NAMESPACE} --logLevel=${LOG_LEVEL}
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -41,3 +41,5 @@ ENV MAX_NUM_VIEWERS "50"
 ENV NAMESPACE "kubeflow"
 
 CMD ["/bin/controller", "-logtostderr=true", "-max_num_viewers=${MAX_NUM_VIEWERS}", "--namespace=${NAMESPACE}"]
+
+# CI noop: same backend Dockerfiles as PR #1435 (CVE bump); no functional change — infra vs PR comparison.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/kubeflow/pipelines
 
+// CI noop: same go.mod paths as PR #1435 (CVE bump); no functional change — infra vs PR comparison.
+
 go 1.24.6
 
 require (

--- a/kubernetes_platform/go.mod
+++ b/kubernetes_platform/go.mod
@@ -1,5 +1,7 @@
 module github.com/kubeflow/pipelines/kubernetes_platform
 
+// CI noop: same go.mod paths as PR #1435 (CVE bump); no functional change — infra vs PR comparison.
+
 go 1.24.6
 
 require (


### PR DESCRIPTION
Touches the same thirteen backend Dockerfiles as the CVE Go builder bump PR to compare CI behavior (repo/infra vs image digest changes).

Open against red-hat-data-services/data-science-pipelines rhoai-3.3.

**Description of your changes:**


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
