### PR TITLE
fix(security): bump Go builder images for CVE-2025-61726

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/pipelines/api
 
-go 1.24.6
+go 1.25.7
 
 require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250715232539-7130f93afb79

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a AS builder
 
 USER root
 

--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for building the source code of cache_server
-FROM golang:1.24-alpine as builder
+FROM golang:1.25.7-alpine as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev

--- a/backend/Dockerfile.conformance
+++ b/backend/Dockerfile.conformance
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for building the source code of conformance tests
-FROM golang:1.24-alpine as builder
+FROM golang:1.25.7-alpine as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -15,7 +15,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a AS builder
 
 
 ## Build args to be used at this step

--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.konflux.driver
+++ b/backend/Dockerfile.konflux.driver
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 
 ## Build args to be used at this step

--- a/backend/Dockerfile.konflux.launcher
+++ b/backend/Dockerfile.konflux.launcher
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.konflux.persistenceagent
+++ b/backend/Dockerfile.konflux.persistenceagent
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.konflux.scheduledworkflow
+++ b/backend/Dockerfile.konflux.scheduledworkflow
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -17,7 +17,7 @@ ARG SOURCE_CODE=.
 ARG CI_CONTAINER_VERSION="unknown"
 
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a AS builder
 
 
 ## Build args to be used at this step

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 ARG CI_CONTAINER_VERSION="unknown"
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -15,7 +15,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:59ec4752cf86f0d0dd240b9e29c64d6ee560c28fc986171e126db1db216a246a AS builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24-alpine as builder
+FROM golang:1.25.7-alpine as builder
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache git gcc musl-dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/pipelines
 
-go 1.24.6
+go 1.25.7
 
 require (
 	github.com/Masterminds/squirrel v0.0.0-20190107164353-fa735ea14f09

--- a/kubernetes_platform/go.mod
+++ b/kubernetes_platform/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/pipelines/kubernetes_platform
 
-go 1.24.6
+go 1.25.7
 
 require (
 	github.com/kubeflow/pipelines/api v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Summary
- Cherry-picks commit `810682def4167c0835e596de87743b2c2377ccca` onto `rhoai-3.3`.
- Bumps Go builder image references to address CVE-2025-61726.
- Keeps the change isolated to this single security fix commit.

## Test plan
- [ ] Confirm CI passes for the `rhoai-3.3` branch checks.
- [ ] Verify container image builds succeed with updated Go builder images.

Made with [Cursor](https://cursor.com)