### PR TITLE
chore: Update Konflux Dockerfiles to use Go toolset 1.26.3 and native Go FIPS 140 configuration

### DIFF
--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.2-1777889793@sha256:1c1259373e6feb4b57de490452379c40888cf6e876154cd2ace17eae9c64a7ea as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -26,8 +26,7 @@ COPY ${SOURCE_CODE}/go.sum ./
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/apiserver ./backend/src/apiserver/ && \
-    dnf clean all
+RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=1 GOFIPS140=v1.0.0 go build -tags no_openssl -o /bin/apiserver ./backend/src/apiserver/
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 

--- a/backend/Dockerfile.konflux.driver
+++ b/backend/Dockerfile.konflux.driver
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.2-1777889793@sha256:1c1259373e6feb4b57de490452379c40888cf6e876154cd2ace17eae9c64a7ea as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 
 ## Build args to be used at this step
@@ -32,7 +32,7 @@ COPY ${SOURCE_CODE}/go.sum ./
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime'  -o /bin/driver ./backend/src/v2/cmd/driver/*.go
+RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOFIPS140=v1.0.0 go build -tags netgo,no_openssl -o /bin/driver ./backend/src/v2/cmd/driver/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 

--- a/backend/Dockerfile.konflux.launcher
+++ b/backend/Dockerfile.konflux.launcher
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.2-1777889793@sha256:1c1259373e6feb4b57de490452379c40888cf6e876154cd2ace17eae9c64a7ea as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -31,16 +31,14 @@ COPY ${SOURCE_CODE}/go.sum ./
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
-RUN GO111MODULE=on CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOEXPERIMENT=strictfipsruntime go build -tags 'netgo strictfipsruntime' -o /bin/launcher-v2-fips ./backend/src/v2/cmd/launcher-v2/*.go
+RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOFIPS140=v1.0.0 go build -tags netgo,no_openssl -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 
 WORKDIR /bin
 
 COPY --from=builder /bin/launcher-v2 /bin/launcher-v2
-COPY --from=builder /bin/launcher-v2-fips /bin/launcher-v2-fips
-RUN chmod +x /bin/launcher-v2 && chmod +x /bin/launcher-v2-fips
+RUN chmod +x /bin/launcher-v2
 
 ENTRYPOINT ["/bin/launcher-v2"]
 

--- a/backend/Dockerfile.konflux.persistenceagent
+++ b/backend/Dockerfile.konflux.persistenceagent
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.2-1777889793@sha256:1c1259373e6feb4b57de490452379c40888cf6e876154cd2ace17eae9c64a7ea as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -31,7 +31,7 @@ COPY ${SOURCE_CODE}/go.sum ./
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/persistence_agent backend/src/agent/persistence/*.go
+RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -tags no_openssl -o /bin/persistence_agent backend/src/agent/persistence/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 

--- a/backend/Dockerfile.konflux.scheduledworkflow
+++ b/backend/Dockerfile.konflux.scheduledworkflow
@@ -16,7 +16,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.2-1777889793@sha256:1c1259373e6feb4b57de490452379c40888cf6e876154cd2ace17eae9c64a7ea as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -31,7 +31,7 @@ COPY ${SOURCE_CODE}/go.sum ./
 # Copy the source
 COPY ${SOURCE_CODE}/ ./
 
-RUN GO111MODULE=on CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go
+RUN GOTOOLCHAIN=local GO111MODULE=on CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -tags no_openssl -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 


### PR DESCRIPTION
## Summary
- Bump go-toolset from 1.26.2 to 1.26.3 with pinned digest in all 5 Konflux Dockerfiles
- Migrate FIPS from `GOEXPERIMENT=strictfipsruntime` to native `GOFIPS140=v1.0.0` with `-tags no_openssl`
- Remove `cmake clang openssl` dependency from api-server build (no longer needed)
- Remove `launcher-v2-fips` dual-binary (single FIPS-enabled binary now)
- API server keeps `CGO_ENABLED=1` (required for go-sqlite3)

Backport of https://github.com/red-hat-data-services/data-science-pipelines/pull/1543 to `rhoai-3.5-ea.2`.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-70532