### PR TITLE
Update OpenSSL version in Dockerfile

### DIFF
--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -20,7 +20,7 @@ ARG SOURCE_CODE
 
 USER root
 
-RUN dnf install -y cmake clang openssl-1:3.5.1-4.el9_7
+RUN dnf install -y cmake clang openssl-1:3.5.1-7.el9_7
 
 
 COPY ${SOURCE_CODE}/go.mod ./


### PR DESCRIPTION
**Description of your changes:**
 Root Cause: openssl version mismatch between Dockerfile and rpms.lock.yaml

  The Dockerfile (backend/Dockerfile.konflux.api:23) pins:
  openssl-1:3.5.1-4.el9_7

  The rpms.lock.yaml (which controls cachi2 prefetch) has:
  openssl-3.5.1-7.el9_7

  The Dockerfile requests version -4.el9_7, but the only version available (both prefetched and in the UBI repos) is -7.el9_7. Since this is a hermetic build, dnf can't
  reach external repos, and the prefetched RPMs only contain -7. The exact NEVRA doesn't match, so dnf fails.

  Timeline

  1. The Dockerfile was originally updated to pin openssl-1:3.5.1-4.el9_7 (commit 1ed770bc by Moulali Shikalwadi, Apr 24).
  2. The rpms.lock.yaml was later refreshed and picked up the newer openssl-3.5.1-7.el9_7 (Feb 23 lock, but the UBI repos have since updated).
  3. A fix already exists on branch remotes/origin/m-rafeeq-patch-8 (commit 847cbbf8 by Mohammed Rafeeq, May 21) that updates the Dockerfile to openssl-1:3.5.1-7.el9_7 —
  but this fix has not been merged into rhoai-3.5 yet. It's only on m-rafeeq-patch-8 and rhoai-3.5-ea.2.


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [ ] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
