### PR TITLE
chore: Remove stale cmake/clang/openssl from api Konflux Dockerfile

### DIFF
--- a/backend/Dockerfile.konflux.api
+++ b/backend/Dockerfile.konflux.api
@@ -20,9 +20,6 @@ ARG SOURCE_CODE
 
 USER root
 
-RUN dnf install -y cmake clang openssl-1:3.5.1-7.el9_7
-
-
 COPY ${SOURCE_CODE}/go.mod ./
 COPY ${SOURCE_CODE}/go.sum ./
 


### PR DESCRIPTION
## Summary
- Remove `cmake`, `clang`, and `openssl` from the api Konflux Dockerfile builder stage
- These were needed for the old OpenSSL-based FIPS build (`GOEXPERIMENT=strictfipsruntime`) but are no longer required with native Go FIPS 140 (`GOFIPS140=v1.0.0`)

Jira: https://redhat.atlassian.net/browse/RHOAIENG-70532