### PR TITLE
fix(backend): tolerate task-level MLflow outages [rhoai-3.5]

### DIFF
--- a/.github/resources/manifests/base/ci-stability-tuning.yaml
+++ b/.github/resources/manifests/base/ci-stability-tuning.yaml
@@ -16,21 +16,3 @@ spec:
           startupProbe:
             failureThreshold: 24
             timeoutSeconds: 5
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: seaweedfs
-  namespace: kubeflow
-spec:
-  template:
-    spec:
-      containers:
-        - name: seaweedfs
-          resources:
-            requests:
-              cpu: 250m
-              memory: 512Mi
-            limits:
-              cpu: "1"
-              memory: 1Gi

--- a/.github/resources/manifests/base/seaweedfs-ci-stability-tuning.yaml
+++ b/.github/resources/manifests/base/seaweedfs-ci-stability-tuning.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      containers:
+        - name: seaweedfs
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
+++ b/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: cache-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/default/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/default/kustomization.yaml
@@ -47,6 +47,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/cache-disabled-tls/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled-tls/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../tls-enabled
+
+patches:
+  - path: ../cache-disabled/cache-env.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline

--- a/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: cache-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/default/kustomization.yaml
+++ b/.github/resources/manifests/standalone/default/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/proxy/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: apiserver-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
@@ -43,6 +43,7 @@ patches:
       kind: Deployment
       name: ml-pipeline
   - path: ../../base/ci-stability-tuning.yaml
+  - path: ../../base/seaweedfs-ci-stability-tuning.yaml
   - path: apiserver-env.yaml
     target:
       kind: Deployment

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Remove the x if you need no print out of each command
-set -e
+set -eo pipefail
 
 REGISTRY="${REGISTRY:-kind-registry:5000}"
 EXIT_CODE=0
@@ -135,6 +135,8 @@ if [ "${MULTI_USER}" == "false" ] && [ "${PIPELINES_STORE}" != "kubernetes" ]; t
   TEST_MANIFESTS="${TEST_MANIFESTS}/standalone"
   if $CACHE_DISABLED && $USE_PROXY; then
     TEST_MANIFESTS="${TEST_MANIFESTS}/cache-disabled-proxy"
+  elif $CACHE_DISABLED && $POD_TO_POD_TLS_ENABLED; then
+    TEST_MANIFESTS="${TEST_MANIFESTS}/cache-disabled-tls"
   elif $CACHE_DISABLED; then
     TEST_MANIFESTS="${TEST_MANIFESTS}/cache-disabled"
   elif $USE_PROXY; then

--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -132,6 +132,7 @@ jobs:
           if [ "${{ env.SKIP_OPERATOR_DEPLOYMENT }}" == "false" ]; then
             kubectl get configmap openshift-service-ca.crt -n kubeflow -o jsonpath='{.data.service-ca\.crt}' > "${{ github.workspace }}/ca.crt"
           else
+            kubectl wait --for=condition=Ready certificate/kfp-api-tls-cert -n kubeflow --timeout=120s
             kubectl get secret kfp-api-tls-cert -n kubeflow -o jsonpath='{.data.ca\.crt}' | base64 -d > "${{ github.workspace }}/ca.crt"
           fi
           echo "CA_CERT_PATH=${{ github.workspace }}/ca.crt" >> "$GITHUB_ENV"

--- a/backend/src/v2/common/plugins/dispatcher.go
+++ b/backend/src/v2/common/plugins/dispatcher.go
@@ -125,6 +125,13 @@ func (t *TaskPluginDispatcherImpl) RetrieveUserContainerEnvVars(taskInfo *TaskIn
 
 	injectVarNameSet := map[string]bool{}
 	for _, handler := range t.handlers {
+		if t.startedHandlers != nil && !t.startedHandlers[handler.Name()] {
+			glog.Infof(
+				"Skipping user container env vars for handler %s (OnTaskStart did not succeed)",
+				handler.Name(),
+			)
+			continue
+		}
 		vars, err := handler.RetrieveUserContainerEnvVars()
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve user container env vars for handler %s: %v", handler.Name(), err)

--- a/backend/src/v2/common/plugins/dispatcher_test.go
+++ b/backend/src/v2/common/plugins/dispatcher_test.go
@@ -278,6 +278,31 @@ func TestRetrieveUserContainerEnvVars_Success(t *testing.T) {
 	assert.Equal(t, expectedVars, vars)
 }
 
+func TestRetrieveUserContainerEnvVars_SkipsFailedHandler(t *testing.T) {
+	expectedVars := []corev1.EnvVar{
+		{Name: "PLUGIN_RUN_ID", Value: "fake-run-1"},
+	}
+	failedHandler := &fakeHandler{
+		name:     "FailedPlugin",
+		startErr: fmt.Errorf("plugin startup failed"),
+		envErr:   fmt.Errorf("env var retrieval should be skipped"),
+	}
+	successfulHandler := &fakeHandler{
+		name:    "SuccessfulPlugin",
+		envVars: expectedVars,
+	}
+	dispatcher, _ := NewTaskPluginDispatcherImpl(
+		[]TaskPluginHandler{failedHandler, successfulHandler},
+	)
+
+	_, err := dispatcher.OnTaskStart(context.Background(), taskInfoStart)
+	require.NoError(t, err)
+	vars, err := dispatcher.RetrieveUserContainerEnvVars(taskInfoEnd)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedVars, vars)
+}
+
 func TestRetrieveUserContainerEnvVars_HandlerError_Propagated(t *testing.T) {
 	handler := &fakeHandler{
 		name:   "FakePlugin",


### PR DESCRIPTION
**Description of your changes:**

Carries kubeflow/pipelines#13938 and
opendatahub-io/data-science-pipelines#427 to `rhoai-3.5`.

Treat task-level MLflow integration as best-effort when a plugin cannot
start. The task plugin dispatcher skips user container environment variable
retrieval for handlers whose `OnTaskStart` call failed. This lets user
containers run during an MLflow outage while preserving environment variables
from plugins that started successfully.

`injectUserEnvVars` controls whether MLflow integration context is exposed; it
does not make MLflow availability a pipeline requirement. Components using
optional MLflow instrumentation can guard it with:

```python
if os.getenv("MLFLOW_RUN_ID"):
    mlflow.autolog()
```

Environment variable construction errors from successfully started plugins
still propagate.

Tests:

- Task plugin dispatcher tests: 20 passed
- MLflow task handler tests: 31 passed

**Checklist:**
- [x] The commit is signed off
- [x] The PR targets `rhoai-3.5`

**CI baseline repair:**

- Add a cache-disabled TLS overlay for the failing matrix combination.
- Wait for the cert-manager Certificate before reading its generated Secret.
- Split the multi-document stability patch for older Kustomize compatibility.
- Enable `pipefail` so manifest rendering failures are reported directly.

Validation:

- All nine affected overlays render with Kustomize 5.0.1.
- The combined overlay contains the TLS Certificate and .
- ShellCheck passes for the deployment script.